### PR TITLE
directional mouse attack and swap weapons

### DIFF
--- a/Assets/Scenes/ProjectileScene.unity
+++ b/Assets/Scenes/ProjectileScene.unity
@@ -9235,8 +9235,8 @@ CanvasRenderer:
 --- !u!1 &772840378
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6025025708376848545, guid: abf54857947005446b83800b0004585b, type: 3}
+  m_PrefabInstance: {fileID: 6025025707874542363}
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
@@ -9253,8 +9253,8 @@ GameObject:
 --- !u!60 &772840379
 PolygonCollider2D:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6025025708376848544, guid: abf54857947005446b83800b0004585b, type: 3}
+  m_PrefabInstance: {fileID: 6025025707874542363}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 772840378}
   m_Enabled: 1
@@ -9319,8 +9319,8 @@ PolygonCollider2D:
 --- !u!212 &772840380
 SpriteRenderer:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6025025708376848551, guid: abf54857947005446b83800b0004585b, type: 3}
+  m_PrefabInstance: {fileID: 6025025707874542363}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 772840378}
   m_Enabled: 1
@@ -9370,8 +9370,8 @@ SpriteRenderer:
 --- !u!4 &772840381
 Transform:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+  m_PrefabInstance: {fileID: 6025025707874542363}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 772840378}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -9379,7 +9379,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &869050377
 GameObject:
@@ -9649,7 +9649,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1539356260
 GameObject:
@@ -9762,8 +9762,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animator: {fileID: 1539356267}
-  attackRate: 1
+  attackRate: 10
   attackDirection: 0
+  angle: 0
+  weapons:
+  - Fists
+  - Sword
+  - Projectile
+  currentWeapon: 
+  currentWeaponIndex: 0
 --- !u!114 &1539356266
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11050,6 +11057,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 1926309499}
   cam: {fileID: 1086931565}
+  mouseCursorPosition: {x: 0, y: 0}
 --- !u!50 &1926309499
 Rigidbody2D:
   serializedVersion: 4
@@ -11237,3 +11245,60 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &6025025707874542363
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6025025708376848545, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_Name
+      value: Villain 01 32_0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6025025708376848550, guid: abf54857947005446b83800b0004585b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: abf54857947005446b83800b0004585b, type: 3}

--- a/Assets/Scripts/CrosshairCursor.cs
+++ b/Assets/Scripts/CrosshairCursor.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class CrosshairCursor : MonoBehaviour
 {
 
+    public static Vector2 mouseCursorPosition;
+
     void Awake()
     {  
         Cursor.visible = false;
@@ -13,7 +15,7 @@ public class CrosshairCursor : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        Vector2 mouseCursorPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-        transform.position = mouseCursorPos;
+        mouseCursorPosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        transform.position = mouseCursorPosition;
     }
 }

--- a/Assets/Scripts/PlayerAttack.cs
+++ b/Assets/Scripts/PlayerAttack.cs
@@ -19,39 +19,67 @@ public class PlayerAttack : MonoBehaviour
 
     public AttackDirection attackDirection;
 
+    public float angle;
+
+    public string[] weapons = {"Fists", "Sword", "Projectile"};
+    public string currentWeapon;
+    public int currentWeaponIndex = 0;
+
     // Update is called once per frame
     void Update()
     {
+        if (Input.GetKeyDown(KeyCode.C)) // Change weapons!
+        {
+            currentWeaponIndex++;
+            if (currentWeaponIndex == weapons.Length) // Cycle through the weapons array! Go back to 0 index
+                currentWeaponIndex = 0;
+            currentWeapon = weapons[currentWeaponIndex];
+        }
+        
+        angle = PlayerShootCam.angle;
+        // if (Input.GetButtonDown("Fire1"))
+        //     Debug.Log("angle: " + angle);
+
         if (Time.time >= nextAttackTime)
         {
-            if (Input.GetKeyDown(KeyCode.Alpha1))
+            if (currentWeapon == "Sword")
             {
-                attackDirection = AttackDirection.Left;
-                Attack();
-                nextAttackTime = Time.time + 1f / attackRate;
+                if ( Input.GetButtonDown("Fire1") && ((angle >= 135 && angle <= 180) || (angle <= -135 && angle >= -180)) ) // LEFT **
+                {
+                    attackDirection = AttackDirection.Left;
+                    Attack();
+                    nextAttackTime = Time.time + 1f / attackRate;
+                    Debug.Log("LEFT");
+                }
+                else if ( Input.GetButtonDown("Fire1") && ((angle <= 45 && angle >= 0) || (angle >= -45 && angle <= 0)) ) // RIGHT
+                {
+                    attackDirection = AttackDirection.Right;
+                    Attack();
+                    nextAttackTime = Time.time + 1f / attackRate;
+                    Debug.Log("RIGHT");
+                }
+                else if (Input.GetButtonDown("Fire1") && angle <= 135 && angle >= 45) // UP
+                {
+                    attackDirection = AttackDirection.Up;
+                    Attack();
+                    nextAttackTime = Time.time + 1f / attackRate;
+                    Debug.Log("UP");                
+                }
+                else if (Input.GetButtonDown("Fire1") && angle >= -135 && angle <= -45) // DOWN
+                {
+                    attackDirection = AttackDirection.Down;
+                    Attack();
+                    nextAttackTime = Time.time + 1f / attackRate;
+                    Debug.Log("DOWN");   
+                }
             }
-            else if (Input.GetKeyDown(KeyCode.Alpha2))
+            else if (currentWeapon == "Projectile")
             {
-                attackDirection = AttackDirection.Right;
-                Attack();
-                nextAttackTime = Time.time + 1f / attackRate;                
-            }
-            else if (Input.GetKeyDown(KeyCode.Alpha3))
-            {
-                attackDirection = AttackDirection.Up;
-                Attack();
-                nextAttackTime = Time.time + 1f / attackRate;                
-            }
-            else if (Input.GetKeyDown(KeyCode.Alpha4))
-            {
-                attackDirection = AttackDirection.Down;
-                Attack();
-                nextAttackTime = Time.time + 1f / attackRate;                
-            }
-            else if (Input.GetButton("Fire1"))
-            {
-                GameObject.Find("PlayerFirepoint").GetComponent<PlayerShoot>().Shoot();
-                nextAttackTime = Time.time + 1f / attackRate;
+                if (Input.GetButtonDown("Fire1"))
+                {
+                    GameObject.Find("PlayerFirepoint").GetComponent<PlayerShoot>().Shoot();
+                    nextAttackTime = Time.time + 1f / attackRate;
+                }
             }
         }
     }

--- a/Assets/Scripts/Projectile/PlayerShootCam.cs
+++ b/Assets/Scripts/Projectile/PlayerShootCam.cs
@@ -7,8 +7,9 @@ public class PlayerShootCam : MonoBehaviour
     public Rigidbody2D rb;
     Vector2 mousePos;
     Vector2 mouseDirection;
-    float angle;
+    public static float angle;
     public Camera cam;
+    public Vector2 mouseCursorPosition;
 
     // Update is called once per frame
     void Update()
@@ -19,13 +20,11 @@ public class PlayerShootCam : MonoBehaviour
         // if (Input.GetButtonDown("Fire1"))
         //     Debug.Log("angle: " + angle);
 
-        mousePos = cam.ScreenToWorldPoint(Input.mousePosition);
+
+        mouseCursorPosition = CrosshairCursor.mouseCursorPosition;
         transform.position = transform.parent.position;
-    }
     
-    void FixedUpdate()
-    {
-        mouseDirection = mousePos - rb.position;
+        mouseDirection = mouseCursorPosition - rb.position;
         angle = Mathf.Atan2(mouseDirection.y, mouseDirection.x) * Mathf.Rad2Deg;
         rb.rotation = angle;
     }


### PR DESCRIPTION
__Discord REPOST__

in this branch, we can swap weapons using key 'c' and the sword attack detects all 4 directions relative to the player position and mouse position

notes:
- use ProjectileScene
- 'c' to swap weapons
- no animations for sword attack UP, LEFT, RIGHT but it should appear in the console